### PR TITLE
optical corrections to work with small displays too

### DIFF
--- a/src/frontend/static/style.css
+++ b/src/frontend/static/style.css
@@ -98,10 +98,10 @@
   box-sizing: border-box;
   color: #fff;
   cursor: pointer;
-  flex: 1 1 0;
+  flex: auto;
   font-size: var(--control-font);
   font-weight: bold;
-  height: var(--kb-btn-size);
+  height: var(--kb-btn-size) !important;
   margin: 0;
   min-width: 0;
   transition: background 0.2s, border 0.2s;
@@ -113,7 +113,6 @@
   flex-direction: column;
   justify-content: flex-start;
   min-width: 0;
-  flex: 0 0 var(--kb-btn-size);
   width: var(--kb-btn-size);
   max-width: var(--kb-btn-size);
   justify-self: center;
@@ -300,7 +299,7 @@
   color: white;
   cursor: pointer;
   margin: 0 0.2rem;
-  padding: 0.4rem 1rem;
+  padding: 0.4rem;
 }
 .tab.active {
   background: #000;
@@ -367,7 +366,7 @@
   --topbar-h: 0px;
   --vh: var(--app-height, 100svh);
   --control-font: clamp(0.9rem, calc(var(--top-btn-h) * 0.40), 1.6rem);
-  --kb-btn-size: calc(var(--app-width) * 0.2);
+  --kb-btn-size: calc(var(--app-height) * 0.11);
   --kb-group-inner-gap: clamp(6px, calc(var(--vh) * 0.03), 20px);
   --kb-header-h: clamp(24px, calc(var(--vh) * 0.06), 64px);
   --kb-gap: clamp(6px, calc(var(--vh) * 0.02), 16px);

--- a/src/frontend/templates/index.html
+++ b/src/frontend/templates/index.html
@@ -38,7 +38,7 @@
         <button id="infoModalClose" class="modal-close" aria-label="Close" data-i18n="common.close" data-i18n-attr="aria-label">×</button>
       </div>
       <div class="modal-body" style="display:flex; flex-direction:column; align-items:center; justify-content:center; gap:1.2rem;">
-        <div style="font-size:clamp(1rem,calc(var(--top-btn-h)*0.40),1.3rem); font-weight:normal; text-align:center;">
+        <div style="font-size:0.9rem; font-weight:normal; text-align:center;">
           <span data-i18n="info.aboutHtml">The source code of this WebApp is publicly available on <a href="https://github.com/RalfMende/MobileStationWebApp" target="_blank">GitHub</a>.<br>There you'll also find the license terms (see LICENSE) and the latest release.</span><br>
           <span data-i18n="info.docsHtml"><a href="https://ralfmende.github.io/MobileStationWebApp/index.html" target="_blank">Online documentation & FAQ</a></span><br>
           <br>
@@ -65,7 +65,7 @@
         <div class="speed-bar-wrapper">
           <div class="speed-bar" id="speedBar">
             <div id="speedFill" class="speed-fill"></div>
-            <input type="range" id="speedSlider" min="0" max="200" value="0" class="slider-vertical"/>
+            <input type="range" id="speedSlider" min="0" max="1000" value="0" class="slider-vertical"/>
           </div>
         </div>
         <div id="locoDesc" class="loco-desc">Select Locomotive</div>


### PR DESCRIPTION
corrections for correct displaying
- headline with tab buttons on small displays (reduce horizontal padding) 
- buttons on keyboard side on small and wide displays (derive from height instead of width)
- info side on small displays (use smaller characters)